### PR TITLE
hosts: get rid of system in nixosSystem

### DIFF
--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -6,10 +6,12 @@
   inherit (self) inputs;
   mkHost = name: system:
     nixpkgs.lib.nixosSystem {
-      inherit system;
       modules =
         [
-          {networking.hostName = name;}
+          {
+            networking.hostName = name;
+            nixpkgs.hostPlatform = system;
+          }
           ./${name}
         ]
         ++ builtins.attrValues self.nixosModules;


### PR DESCRIPTION
This is more or less an anti-pattern that is expected to be deprecated for modularity. Using hostPlatform makes it easier to override or read within the module system.